### PR TITLE
Add function to get structured goal progress data

### DIFF
--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -362,6 +362,11 @@ class ScienceWorldEnv:
         goalStr = self.gateway.getGoalProgressStr()
         return goalStr
 
+    def getGoalProgressJSON(self):
+        jsonStr = self.gateway.getGoalProgressJSON()
+        data = json.loads(jsonStr)
+        return data
+
 
 class BufferedHistorySaver:
 

--- a/simulator/src/main/scala/scienceworld/runtime/AgentInterface.scala
+++ b/simulator/src/main/scala/scienceworld/runtime/AgentInterface.scala
@@ -393,6 +393,10 @@ class AgentInterface(val universe:EnvObject, val agent:Agent, val task:Task, var
     return this.task.goalSequence.getProgressString()
   }
 
+  def getGoalProgressJSON():String = {
+    return this.task.goalSequence.toJSON()
+  }
+
 
   /*
    * Error Handling

--- a/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
+++ b/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
@@ -329,6 +329,8 @@ class PythonInterface() {
 
   def getGoalProgressStr():String = agentInterface.get.getGoalProgressStr()
 
+  def getGoalProgressJSON():String = agentInterface.get.getGoalProgressJSON()
+
   def getCompleted():Boolean = this.isComplete
 
   // Normal

--- a/simulator/src/main/scala/scienceworld/tasks/goals/Goal.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/goals/Goal.scala
@@ -2,8 +2,10 @@ package scienceworld.tasks.goals
 
 import scienceworld.objects.agent.Agent
 import scienceworld.struct.EnvObject
+import scienceworld.struct.EnvObject.MODE_CURSORY_DETAIL
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.util.control.Breaks._
 
 // Storage class for a single goal
@@ -331,9 +333,82 @@ class GoalSequence(val subgoals:Array[Goal], optionalUnorderedSubgoals:Array[Goa
     os.toString()
   }
 
+  def toJSONArray(goals: Array[Goal], requiredGoals: Boolean): String = {
+    val jsonGoals = new ArrayBuffer[String]
+    for (i <- 0 until goals.length) {
+      val goal = goals(i)
+      val goalDescription = goal.description
+      val goalClass = goal.getClass.toString.split("\\.").last
+      val key = goal.key
+      val keysMustBeCompletedBefore = goal.keysMustBeCompletedBefore
+      val keysMustBeCompletedBeforeJSON = "[" +
+        keysMustBeCompletedBefore.map(s => "\"" + GoalSequence.sanitizeJSON(s) + "\"").mkString(", ") + "]"
+      val satisfiedWithObject = goal.satisfiedWithObject
+      val satisfiedWithObjectJSON =
+        if (satisfiedWithObject.isDefined) {
+          "\"" +  GoalSequence.sanitizeJSON(satisfiedWithObject.get.getDescription(MODE_CURSORY_DETAIL)) + "\""
+        } else {"null"}
+      val defocusOnSuccess = goal.defocusOnSuccess
+      val isOptional = goal.isOptional
+      val passed =
+        if (requiredGoals) {
+          i < this.curSubgoalIdx
+        } else {
+          this.optionalUnorderedSubgoalsCompleted(i)
+        }
+
+      val json = new StringBuilder
+      json.append("{")
+      json.append("\"description\":\"" + GoalSequence.sanitizeJSON(goalDescription) + "\", ")
+      json.append("\"class\":\"" + GoalSequence.sanitizeJSON(goalClass) + "\", ")
+      json.append("\"key\":\"" + GoalSequence.sanitizeJSON(key) + "\", ")
+      json.append("\"keysMustBeCompletedBefore\":" + keysMustBeCompletedBeforeJSON + ", ")
+      json.append("\"satisfiedWithObject\":" + satisfiedWithObjectJSON + ", ")
+      json.append("\"defocusOnSuccess\":" + defocusOnSuccess + ", ")
+      json.append("\"isOptional\":" + isOptional + ", ")
+      json.append("\"passed\":" + passed + "")
+      json.append("}")
+
+      jsonGoals.append(json.toString())
+    }
+
+    val jsonOut = "[" + jsonGoals.mkString(", ") + "]"
+
+    return jsonOut
+  }
+
+  def toJSON(): String = {
+    val completedKeysJSON =
+      "[" +
+        this.completedKeys.toList.sorted.map(GoalSequence.sanitizeJSON).map(s => "\"" + s + "\"").mkString(", ") + "]"
+
+    val json = new StringBuilder
+    json.append("{")
+    json.append("\"isFailed\":" + this.isFailed() + ", ")
+    json.append("\"completedKeys\":" + completedKeysJSON + ", ")
+    json.append("\"sequentialSubgoals\":" + toJSONArray(subgoals, requiredGoals = true) + ", ")
+    json.append("\"unorderedSubgoals\":" + toJSONArray(optionalUnorderedSubgoals, requiredGoals = false))
+    json.append("}")
+
+    return json.toString
+  }
+
 
 }
 
+object GoalSequence {
+
+  def sanitizeJSON(in:String):String = {
+    var out = in.replace("\\", "\\\\")
+    out = out.replace("\"", "\\\"")
+    out = out.replace("\n", "\\n")
+    out = out.replace("\r", "\\r")
+    out = out.replace("\t", "\\t")
+
+    return out
+  }
+
+}
 
 // Storage class for return values
 class GoalReturn(val subgoalSuccess:Boolean, val taskFailure:Boolean) {


### PR DESCRIPTION
For <https://github.com/isi-vista/mics-text-games/issues/37>.

The new function, `ScienceWorldEnv.getGoalProgressJSON()`, returns as much data stored in the goal objects as possible. For ease of reference, I kept most of the original field names. I don't know what would be useful, so I figured we might as well output everything.

The first two commits make the observation outlook reproducible, which makes diffing output during development much easier. They will be removed before this PR is merged.

The new logic in `Goal.scala` is largely based off logic from [RunHistory.toJSON()](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/simulator/src/main/scala/scienceworld/goldagent/ExampleGoldAgent.scala#L348). One thing to note is that I fixed a bug in the copy of [RunHistory.sanitizeJSON()](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/simulator/src/main/scala/scienceworld/goldagent/ExampleGoldAgent.scala#L397) that I created. It should probably be fixed in `RunHistory` itself or factored out into [`StringHelpers.scala`](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/simulator/src/main/scala/util/StringHelpers.scala), but that is a problem for another time.

I did enough testing that all lines of code I've written should have been run, but I'm leaving tests to run on SAGA overnight to verify I don't have any bugs that only occur for specific task variations. For quick turnaround during development, I used [test_goals.py](https://github.com/isi-vista/ScienceWorld/files/9312565/test_goals.py.zip).