### PR TITLE
Output action validity from step info

### DIFF
--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -311,6 +311,7 @@ class ScienceWorldEnv:
     # Step
     def step(self, inputStr:str):
         observation = self.gateway.step(inputStr)
+        success = self.gateway.getSuccess()
         score = int(round(100 * self.gateway.getScore()))        # Convert from 0-1 to 0-100
         isCompleted = self.gateway.getCompleted()
         numMoves = self.getNumMoves()
@@ -336,6 +337,7 @@ class ScienceWorldEnv:
         infos = {'moves': numMoves,
                  'score': score,
                  'reward': reward,
+                 'isValidAction': success,
                  'look': self.look(),
                  'inv': self.inventory(),
                  'taskDesc': self.taskdescription(),

--- a/simulator/src/main/scala/scienceworld/input/ActionHandler.scala
+++ b/simulator/src/main/scala/scienceworld/input/ActionHandler.scala
@@ -11,6 +11,7 @@ class ActionHandler {
   val actions = mutable.Map[String, ActionRequestDef]()
 
   val queuedActions = new ArrayBuffer[Action]()
+  val successHistory = new ArrayBuffer[Boolean]()
   val actionHistory = new ArrayBuffer[ Array[Action] ]()
 
   /*
@@ -56,6 +57,7 @@ class ActionHandler {
       println ("Running action: " + action.name)
 
       val (resultDesc, success) = action.runAction()
+      successHistory.append(success)
 
       // Record the action in the agent's action history
       if (action.assignments.contains("agent")) {

--- a/simulator/src/main/scala/scienceworld/runtime/AgentInterface.scala
+++ b/simulator/src/main/scala/scienceworld/runtime/AgentInterface.scala
@@ -53,6 +53,7 @@ class AgentInterface(val universe:EnvObject, val agent:Agent, val task:Task, var
   // Input parser
   val inputParser = new InputParser(actionHandler.getActions())
 
+  var isActionParseValid: Boolean = false
 
   private var curIter:Int = 0
 
@@ -506,6 +507,7 @@ class AgentInterface(val universe:EnvObject, val agent:Agent, val task:Task, var
 
   // Returns (observation, score, isCompleted)
   def step(userInputStr: String): (String, Double, Boolean) = {
+    isActionParseValid = false
     val userOutStr = new StringBuilder()
 
 
@@ -516,6 +518,7 @@ class AgentInterface(val universe:EnvObject, val agent:Agent, val task:Task, var
 
     // Parse user input
     val (success, statusStr) = this.processUserInput(userInputStr, universe)
+    isActionParseValid = success
 
     /*
     // Uncomment to include the user input parse success/failure in the string (e.g. "successfully parsed action (look around)")

--- a/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
+++ b/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
@@ -37,6 +37,7 @@ class PythonInterface() {
 
   var score:Double = 0.0
   var isComplete:Boolean = false
+  var success:Boolean = false
 
   var errorUnknownEnvironment:Boolean = false
   var errorStr:String = ""
@@ -333,8 +334,11 @@ class PythonInterface() {
 
   def getCompleted():Boolean = this.isComplete
 
+  def getSuccess():Boolean = this.success
+
   // Normal
   def step(userInputString:String): String = {
+    this.success = false
     val outStr = new StringBuilder
     // Error checking
     if (this.errorStr != "") return this.errorStr
@@ -365,6 +369,7 @@ class PythonInterface() {
     val (description, score_, isCompleted_) = agentInterface.get.step(userInputString)
     this.score = score_
     this.isComplete = isCompleted_
+    this.success = agentInterface.get.isActionParseValid && agentInterface.get.actionHandler.successHistory.last
 
     // Store in history
     currentHistory.addStep(userInputString, (description, score_, isCompleted_), freelookStr, inventoryStr)


### PR DESCRIPTION
For <https://github.com/isi-vista/mics-text-games/issues/59>.

`ScienceWorldEnv.step()` now includes a boolean `isValidAction` field that records whether the provided action was valid in the context of the current environment and ran without errors. Although there are many different approaches I've tried, this is the least invasive that @manuelciosici and I came up with.

For testing, I created [test_validity.py](https://github.com/isi-vista/ScienceWorld/files/9538196/test_validity.py.zip), which produces the following output:

```text
Launching ScienceWorld Server (Port 25335) -- this may take a moment.
Load:  (variation: 0) (simplifications: )
Load: task-1-boil (variation: 4) (simplifications: )

Action: 'look around'
Observation: 'This room is called the hallway. In it, you see: \n\tthe agent\n\ta picture\n\ta substance called air\nYou also see:\n\tA door to the workshop (that is closed)\n\tA door to the art studio (that is closed)\n\tA door to the kitchen (that is closed)\n\tA door to the living room (that is closed)\n\tA door to the green house (that is closed)\n\tA door to the bedroom (that is closed)'
Is valid action: True

Action: 'lorem ipsum'
Observation: 'No known action matches that input.'
Is valid action: False

Action: 'focus on metal pot'
Observation: 'No known action matches that input.'
Is valid action: False

Action: 'focus on picture'
Observation: 'You focus on the picture.'
Is valid action: True

Action: 'eat picture'
Observation: 'The picture is not edible.'
Is valid action: False
```

I also tested with this branch incorporated into MASC.